### PR TITLE
Fix build error in Xcode 13.

### DIFF
--- a/Sources/HTTPManager.swift
+++ b/Sources/HTTPManager.swift
@@ -1761,27 +1761,22 @@ public final class HTTPManagerMetricsCallback: NSObject {
 
 // MARK: - Private
 
-// Stored properties cannot be marked potentially unavailable with @unavailable.
-// Therefore we will use a custom enum for this.
-private enum MetricsCallbackWrapper {
-    case none
-    @available(iOS 10, macOS 10.12, tvOS 10, watchOS 3, *)
-    case some(HTTPManager.MetricsCallback)
+// Wraps a `MetricsCallback` because stored properties cannot be marked potentially unavailable with @unavailable.
+private struct MetricsCallbackWrapper {
+    static var none: MetricsCallbackWrapper { return MetricsCallbackWrapper() }
     
+    private var wrapped: Any?
+
     @available(iOS 10, macOS 10.12, tvOS 10, watchOS 3, *)
     init(_ metricsCallback: HTTPManager.MetricsCallback?) {
-        switch metricsCallback {
-        case .none: self = .none
-        case .some(let value): self = .some(value)
-        }
+        wrapped = metricsCallback
     }
+    
+    private init() {}
     
     @available(iOS 10, macOS 10.12, tvOS 10, watchOS 3, *)
     var asOptional: HTTPManager.MetricsCallback? {
-        switch self {
-        case .none: return .none
-        case .some(let value): return .some(value)
-        }
+        return wrapped as? HTTPManager.MetricsCallback
     }
 }
 


### PR DESCRIPTION
Enum cases with associated types can no longer be marked as unavailable with @available in Xcode 13/Swift 5.5, this is causing a build break in `MetricsCallbackWrapper`.

<img width="1032" alt="Screen Shot 2021-07-02 at 10 26 47 AM" src="https://user-images.githubusercontent.com/86796215/124309769-156f8a80-db20-11eb-8ff6-c1c067acb60f.png">

This PR changes `MetricsCallbackWrapper` to be a struct with a private `Any?` value that is unwrapped as `MetricsCallback?` when needed. The usage is the same so no other code changes are required.

Tests pass on Xcode 12.5 and 13b2.